### PR TITLE
Fix failing API tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
   3at-postgres:
     container_name: 3at-postgres
     build: ./docker/postgres
+    environment:
+      POSTGRES_HOST_AUTH_METHOD: trust
     ports:
       - "5432:5432"
   3at-api:

--- a/web-api/src/integration-tests/authentication.spec.ts
+++ b/web-api/src/integration-tests/authentication.spec.ts
@@ -20,53 +20,52 @@ const clientSecret = '5r5rd15c650f4849119eb894939d9fdaaf5f7d0e7e0f65de15b71bfa64
 const agent = chai.request.agent(app);
 
 describe('Authentication tests', () => {
-// tslint:disable-next-line: no-commented-code
-  // it('Should not be able to log in with invalid credentials', (done) => {
-  //   agent.post('/api/v1/auth/token')
-  //     .send(`username=${username}&password=invalid_password&client_id=${clientId}&client_secret=${clientSecret}&grant_type=password`)
-  //     .end((err, res) => {
-  //       assert.isNull(err);
-  //       expect(res.body.message).to.equal('Invalid username or password');
-  //       expect(res).to.have.status(HttpStatus.INTERNAL_SERVER_ERROR);
-  //       done(err);
-  //     });
-  // });
-  // it('Should get access and refresh tokens when logged in successfully', (done) => {
-  //   agent.post('/api/v1/auth/token')
-  //     .send(`username=${username}&password=${password}&client_id=${clientId}&client_secret=${clientSecret}&grant_type=password`)
-  //     .end((err, res) => {
-  //       assert.isNull(err);
-  //       assert.isNotNull(res.body.accessToken);
-  //       assert.isNotNull(res.body.refreshToken);
-  //       expect(res).to.have.status(HttpStatus.OK);
-  //       expect(res, 'accessToken cookie not found').to.have.cookie('accessToken');
-  //       done(err);
-  //     });
-  // });
-  // it('Should get account details', (done) => {
-  //   agent.get('/api/v1/account/me')
-  //     .end((err, res) => {
-  //       assert.isNull(err);
-  //       expect(res.body.username).to.equal(username);
-  //       expect(res).to.have.status(HttpStatus.OK);
-  //       done(err);
-  //     });
-  // });
-  // it('Should log out', (done) => {
-  //   agent.get('/api/v1/auth/logout')
-  //     .end((err, res) => {
-  //       assert.isNull(err);
-  //       expect(res.body.message).to.equal('Logged out successfully');
-  //       expect(res).to.have.status(HttpStatus.OK);
-  //       done(err);
-  //     });
-  // });
-  // it('Should get HTTP unauthorized when getting the account after logged out', (done) => {
-  //   agent.get('/api/v1/account/me')
-  //     .end((err, res) => {
-  //       assert.isNull(err);
-  //       expect(res).to.have.status(HttpStatus.UNAUTHORIZED);
-  //       done(err);
-  //     });
-  // });
+  it('Should not be able to log in with invalid credentials', (done) => {
+    agent.post('/api/v1/auth/token')
+      .send(`username=${username}&password=invalid_password&client_id=${clientId}&client_secret=${clientSecret}&grant_type=password`)
+      .end((err, res) => {
+        assert.isNull(err);
+        expect(res.body.message).to.equal('Invalid username or password');
+        expect(res).to.have.status(HttpStatus.INTERNAL_SERVER_ERROR);
+        done(err);
+      });
+  });
+  it('Should get access and refresh tokens when logged in successfully', (done) => {
+    agent.post('/api/v1/auth/token')
+      .send(`username=${username}&password=${password}&client_id=${clientId}&client_secret=${clientSecret}&grant_type=password`)
+      .end((err, res) => {
+        assert.isNull(err);
+        assert.isNotNull(res.body.accessToken);
+        assert.isNotNull(res.body.refreshToken);
+        expect(res).to.have.status(HttpStatus.OK);
+        expect(res, 'accessToken cookie not found').to.have.cookie('accessToken');
+        done(err);
+      });
+  });
+  it('Should get account details', (done) => {
+    agent.get('/api/v1/account/me')
+      .end((err, res) => {
+        assert.isNull(err);
+        expect(res.body.username).to.equal(username);
+        expect(res).to.have.status(HttpStatus.OK);
+        done(err);
+      });
+  });
+  it('Should log out', (done) => {
+    agent.get('/api/v1/auth/logout')
+      .end((err, res) => {
+        assert.isNull(err);
+        expect(res.body.message).to.equal('Logged out successfully');
+        expect(res).to.have.status(HttpStatus.OK);
+        done(err);
+      });
+  });
+  it('Should get HTTP unauthorized when getting the account after logged out', (done) => {
+    agent.get('/api/v1/account/me')
+      .end((err, res) => {
+        assert.isNull(err);
+        expect(res).to.have.status(HttpStatus.UNAUTHORIZED);
+        done(err);
+      });
+  });
 });


### PR DESCRIPTION
The tests stopped working when empty passwords were no longer accepted, see: https://github.com/docker-library/postgres/commit/42ce7437ee68150ee29f5272428aa4fc657dc6dc

Fixes #16