### PR TITLE
#28 Improve HTTP messages for errors

### DIFF
--- a/web-api/src/common/error/app-error.ts
+++ b/web-api/src/common/error/app-error.ts
@@ -4,17 +4,17 @@
  * Available under MIT license webApi/LICENSE
  */
 
-export interface ErrorParameters {
+export interface IAppErrorParameters {
   message: string;
   httpStatusCode: number;
   stack?: string;
   name?: string;
 }
 
-export class AppError extends Error implements ErrorParameters {
+export class AppError extends Error implements IAppErrorParameters {
   public httpStatusCode: number;
 
-  constructor(parameters: ErrorParameters) {
+  constructor(parameters: IAppErrorParameters) {
     super(parameters.message);
     this.httpStatusCode = parameters.httpStatusCode;
     this.stack = parameters.stack;

--- a/web-api/src/common/error/app-error.ts
+++ b/web-api/src/common/error/app-error.ts
@@ -3,21 +3,27 @@
  * Copyright (c) 2018 THREEANGLE SOFTWARE SOLUTIONS SRL
  * Available under MIT license webApi/LICENSE
  */
+import * as HttpStatus from 'http-status-codes';
 
 export interface IAppErrorParameters {
+  httpStatusCode?: number;
   message: string;
-  httpStatusCode: number;
-  stack?: string;
-  name?: string;
+  name: string;
+  originalError?: Readonly<Error>;
 }
 
 export class AppError extends Error implements IAppErrorParameters {
-  public httpStatusCode: number;
+  public readonly httpStatusCode: number;
+  public readonly message: string;
+  public readonly name: string;
+  public readonly originalError?: Readonly<Error>;
 
   constructor(parameters: IAppErrorParameters) {
-    super(parameters.message);
-    this.httpStatusCode = parameters.httpStatusCode;
-    this.stack = parameters.stack;
+    // NOTE: To avoid `enumerable: false` issues, the Error class is called without any arguments.
+    super();
+    this.httpStatusCode = parameters.httpStatusCode || HttpStatus.INTERNAL_SERVER_ERROR;
+    this.message = parameters.message || HttpStatus.getStatusText(this.httpStatusCode);
     this.name = parameters.name;
+    this.originalError = parameters.originalError || undefined;
   }
 }

--- a/web-api/src/common/error/get-error-response.ts
+++ b/web-api/src/common/error/get-error-response.ts
@@ -5,10 +5,9 @@
  */
 import * as HttpStatus from 'http-status-codes';
 
-import { isNil } from '../utils';
-
 import { AppError } from './app-error';
 
+// tslint:disable-next-line:cyclomatic-complexity
 function getStatusFromError(err: unknown): number {
   if (err.hasOwnProperty('message')) {
     if (err['message'] instanceof AppError) {

--- a/web-api/src/common/error/get-error-response.ts
+++ b/web-api/src/common/error/get-error-response.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright (c) 2020 THREEANGLE SOFTWARE SOLUTIONS SRL
+ * Available under MIT license webApi/LICENSE
+ */
+import * as HttpStatus from 'http-status-codes';
+
+import { isNil } from '../utils';
+
+import { AppError } from './app-error';
+
+function getStatusFromError(err: unknown): number {
+  if (err.hasOwnProperty('message')) {
+    if (err['message'] instanceof AppError) {
+      return err['message'].httpStatusCode;
+    }
+  }
+  if (err.hasOwnProperty('inner')) {
+    if (err['inner'] instanceof AppError) {
+      return err['inner'].httpStatusCode;
+    }
+  }
+    if (err.hasOwnProperty('status') && typeof err['status'] === 'number') {
+    return err['status'];
+  } else if (err.hasOwnProperty('statusCode') && typeof err['statusCode'] === 'number') {
+    return err['status'];
+  } else if (err.hasOwnProperty('code') && typeof err['code'] === 'number') {
+    return err['status'];
+  }
+
+  return HttpStatus.INTERNAL_SERVER_ERROR;
+}
+
+export function getErrorResponse(err: unknown): AppError {
+  if (err instanceof AppError) {
+    // NOTE: The original error is not returned to the user.
+    return new AppError({
+      httpStatusCode: err.httpStatusCode,
+      message: err.message,
+      name: err.name,
+    });
+  } else if (typeof err === 'string') {
+    return new AppError({
+      httpStatusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: err,
+      name: 'INTERNAL_SERVER_ERROR',
+    });
+  } else if (typeof err !== 'object') {
+    return new AppError({
+      httpStatusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+      message: HttpStatus.getStatusText(HttpStatus.INTERNAL_SERVER_ERROR),
+      name: 'INTERNAL_SERVER_ERROR',
+    });
+  }
+
+  let innerError: unknown;
+  if (err['inner'] !== undefined) {
+    innerError = err['inner'];
+  } else if (err['message'] !== undefined) {
+    innerError = err ['message'];
+  }
+
+  const statusCode = getStatusFromError(err);
+  if (innerError instanceof AppError) {
+    return new AppError({
+      httpStatusCode: statusCode,
+      message: innerError.message,
+      name: innerError.name,
+    });
+  } else if (innerError instanceof Error) {
+    return new AppError({
+      httpStatusCode: statusCode,
+      message: innerError.message,
+      name: 'UNKNOWN_ERROR',
+    });
+  } else if (typeof innerError === 'string') {
+    return new AppError({
+      httpStatusCode: statusCode,
+      message: innerError,
+      name: 'UNKNOWN_ERROR',
+    });
+  }
+
+  return new AppError({
+    httpStatusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+    message: HttpStatus.getStatusText(HttpStatus.INTERNAL_SERVER_ERROR),
+    name: 'INTERNAL_SERVER_ERROR',
+  });
+}

--- a/web-api/src/common/error/invalid-request-error.ts
+++ b/web-api/src/common/error/invalid-request-error.ts
@@ -9,7 +9,7 @@ import { AppError, IAppErrorParameters } from './app-error';
 
 export class InvalidRequestError extends AppError {
   constructor(options: IAppErrorParameters) {
-    options.httpStatusCode = HttpStatus.BAD_REQUEST;
+    options.httpStatusCode = options.httpStatusCode || HttpStatus.BAD_REQUEST;
     super(options);
   }
 }

--- a/web-api/src/common/error/invalid-request-error.ts
+++ b/web-api/src/common/error/invalid-request-error.ts
@@ -5,10 +5,10 @@
  */
 
 import * as HttpStatus from 'http-status-codes';
-import { AppError, ErrorParameters } from './app-error';
+import { AppError, IAppErrorParameters } from './app-error';
 
 export class InvalidRequestError extends AppError {
-  constructor(options: ErrorParameters) {
+  constructor(options: IAppErrorParameters) {
     options.httpStatusCode = HttpStatus.BAD_REQUEST;
     super(options);
   }

--- a/web-api/src/common/error/unauthorized-error.ts
+++ b/web-api/src/common/error/unauthorized-error.ts
@@ -5,10 +5,11 @@
  */
 
 import * as HttpStatus from 'http-status-codes';
-import { AppError, ErrorParameters } from './app-error';
+
+import { AppError, IAppErrorParameters } from './app-error';
 
 export class UnauthorizedError extends AppError {
-  constructor(options: ErrorParameters) {
+  constructor(options: IAppErrorParameters) {
     options.httpStatusCode = HttpStatus.UNAUTHORIZED;
     super(options);
   }

--- a/web-api/src/common/error/unauthorized-error.ts
+++ b/web-api/src/common/error/unauthorized-error.ts
@@ -10,7 +10,7 @@ import { AppError, IAppErrorParameters } from './app-error';
 
 export class UnauthorizedError extends AppError {
   constructor(options: IAppErrorParameters) {
-    options.httpStatusCode = HttpStatus.UNAUTHORIZED;
+    options.httpStatusCode = options.httpStatusCode || HttpStatus.UNAUTHORIZED;
     super(options);
   }
 }

--- a/web-api/src/modules/security/controllers/auth.controller.ts
+++ b/web-api/src/modules/security/controllers/auth.controller.ts
@@ -3,7 +3,7 @@
  * Copyright (c) 2019 THREEANGLE SOFTWARE SOLUTIONS SRL
  * Available under MIT license webApi/LICENSE
  */
-
+/* tslint:disable:max-file-line-count */
 import { NextFunction } from 'express';
 import { inject, injectable } from 'inversify';
 import { IConfigurationService, OAuthConfiguration } from '../../../common/configuration';

--- a/web-api/src/modules/security/controllers/auth.controller.ts
+++ b/web-api/src/modules/security/controllers/auth.controller.ts
@@ -84,7 +84,14 @@ export class AuthController implements IAuthController {
     if (!req.body.username && req.body.email) {
       try {
         const loadedUser: User = await this.accountService.findByField('email', req.body.email);
-        req.body.username = loadedUser.username;
+        if (loadedUser) {
+          req.body.username = loadedUser.username;
+        } else {
+          return next(new InvalidRequestError({
+            message: 'Invalid credentials.',
+            name: 'INVALID_CREDENTIALS',
+          }));
+        }
       } catch (err) {
         return next(err);
       }

--- a/web-api/src/modules/security/controllers/auth.controller.ts
+++ b/web-api/src/modules/security/controllers/auth.controller.ts
@@ -6,9 +6,10 @@
 /* tslint:disable:max-file-line-count */
 import { NextFunction } from 'express';
 import { inject, injectable } from 'inversify';
+
 import { IConfigurationService, OAuthConfiguration } from '../../../common/configuration';
 import { ForgotPasswordParameters, IEmailService } from '../../../common/email';
-import { InvalidRequestError } from '../../../common/error';
+import { InvalidRequestError, UnauthorizedError } from '../../../common/error';
 import { isNil } from '../../../common/utils';
 import { AppRequest, AppResponse } from '../../../core';
 import { DatabaseModel, IDatabaseContext, User } from '../../../data';
@@ -21,6 +22,7 @@ import {
 } from '../services/account.service.interface';
 import { IJwtTokenService } from '../services/jwt-token.service.interface';
 import { IOAuthServer } from '../services/oauth-server.interface';
+
 import {
   accessTokenCookieName,
   authenticatedCookieName,
@@ -72,8 +74,8 @@ export class AuthController implements IAuthController {
       const refreshToken = req.cookies[refreshTokenCookieName];
       if (isNil(accessToken) || isNil(refreshToken)) {
         return next(new InvalidRequestError({
-          httpStatusCode: 400,
           message: 'Missing authentication information.',
+          name: 'NO_AUTH_CREDENTIALS',
         }));
       }
       // TODO: Reformat the code to avoid updating these values.
@@ -149,9 +151,10 @@ export class AuthController implements IAuthController {
         password: passwordChange.currentPassword,
       });
       if (isNil(verifiedUser)) {
-        return next(new InvalidRequestError({
+        return next(new UnauthorizedError({
           httpStatusCode: 403,
-          message: 'Invalid password',
+          name: 'INVALID_PASSWORD',
+          message: 'Invalid password.',
         }));
       }
 
@@ -181,8 +184,8 @@ export class AuthController implements IAuthController {
       if (isNil(userObject)) {
         // TODO: Refactor message to avoid disclosing user account existence via forgot password requests.
         return next(new InvalidRequestError({
-          httpStatusCode: 400,
           message: 'Invalid email.',
+          name: 'INVALID_EMAIL',
         }));
       }
 

--- a/web-api/src/modules/security/controllers/sandbox.controller.ts
+++ b/web-api/src/modules/security/controllers/sandbox.controller.ts
@@ -48,8 +48,9 @@ export class SandboxController implements ISandboxController {
       user = await this.accountService.find(userId);
       if (isNil(user)) {
         return next(new InvalidRequestError({
-          httpStatusCode: 400,
+          httpStatusCode: 404,
           message: 'User not found',
+          name: 'NOT_FOUND',
         }));
       }
 

--- a/web-api/src/modules/security/middlewares/authenticated-user.middleware.ts
+++ b/web-api/src/modules/security/middlewares/authenticated-user.middleware.ts
@@ -8,14 +8,27 @@ import { NextFunction } from 'express';
 import { UnauthorizedError } from '../../../common/error';
 import { isNil } from '../../../common/utils';
 import { AppRequest, AppResponse, UserContext } from '../../../core';
-import { accessTokenCookieName } from '../controllers/auth.controller.interface';
+import {
+  accessTokenCookieName,
+  authenticatedCookieName,
+  refreshTokenCookieName,
+} from '../controllers/auth.controller.interface';
 
 export async function authenticatedUserMiddleware(req: AppRequest, res: AppResponse, next: NextFunction): Promise<void> {
   // when accessToken is sent via cookie, we initialize the authorization header used by the oauth middleware
   const accessToken = req.cookies[accessTokenCookieName];
-  if (!isNil(accessToken)) {
-    req.headers.authorization = `Bearer ${accessToken}`;
+  if (isNil(accessToken)) {
+    res.clearCookie(accessTokenCookieName);
+    res.clearCookie(refreshTokenCookieName);
+    res.clearCookie(authenticatedCookieName);
+
+    return next(new UnauthorizedError({
+      name: 'UNAUTHORIZED_REQUEST',
+      message: 'Unauthorized request.',
+    }));
   }
+  req.headers.authorization = `Bearer ${accessToken}`;
+
   try {
     const oauthServer = req.getAppContext().getOAuthServer();
     const token = await oauthServer.authenticate(req, res);

--- a/web-api/src/modules/security/middlewares/authenticated-user.middleware.ts
+++ b/web-api/src/modules/security/middlewares/authenticated-user.middleware.ts
@@ -40,6 +40,10 @@ export async function authenticatedUserMiddleware(req: AppRequest, res: AppRespo
     res.locals.userContext = userContext;
     return next();
   } catch (err) {
-    return next(new UnauthorizedError(err));
+    return next(new UnauthorizedError({
+      name: 'UNAUTHORIZED_REQUEST',
+      message: 'Unauthorized request.',
+      originalError: err,
+    }));
   }
 }

--- a/web-api/src/modules/security/services/account.service.ts
+++ b/web-api/src/modules/security/services/account.service.ts
@@ -6,9 +6,11 @@
 
 import { inject, injectable } from 'inversify';
 import { UpdateOptions } from 'sequelize';
+
 import { IConfigurationService, OAuthConfiguration } from '../../../common/configuration';
 import { encrypt, verify } from '../../../common/crypto';
 import { ActivateAccountParameters, IEmailService } from '../../../common/email';
+import { InvalidRequestError } from '../../../common/error';
 import { IJsonConverterService } from '../../../common/json-converter';
 import { Logger, LogLevel } from '../../../common/logger';
 import { isNil } from '../../../common/utils';
@@ -38,12 +40,18 @@ export class AccountService implements IAccountService {
       },
     });
     if (isNil(userObject)) {
-      throw new Error('Invalid username or password');
+      throw new InvalidRequestError({
+        message: 'Invalid credentials.',
+        name: 'INVALID_CREDENTIALS',
+      });
     }
     const user: User = this.jsonConverter.deserialize(userObject, User);
     const valid = verify(credentials.password, user.password);
     if (!valid) {
-      throw new Error('Invalid username or password');
+      throw new InvalidRequestError({
+        message: 'Invalid credentials.',
+        name: 'INVALID_CREDENTIALS',
+      });
     }
     return user;
   }
@@ -55,7 +63,11 @@ export class AccountService implements IAccountService {
       },
     });
     if (isNil(userObject)) {
-      throw new Error('Account not found');
+      throw new InvalidRequestError({
+        httpStatusCode: 404,
+        message: 'Account not found.',
+        name: 'NOT_FOUND',
+      });
     }
     return this.jsonConverter.deserialize(userObject, User);
   }


### PR DESCRIPTION
Refactored the error handler to always return a known format, regardless of the error. This way we can provide relevant translations; including "Unknown error. Try again later" as a generic error.

Required for 3angleTech/webFrame#140

Fixes #28