### PR TITLE
Add X-WebApiVersion header to all API responses

### DIFF
--- a/web-api/src/app.ts
+++ b/web-api/src/app.ts
@@ -15,6 +15,7 @@ import { IDatabaseContext } from './data';
 import { IHealthCheckController } from './modules/health-check';
 import { authenticatedUserMiddleware, IAuthController, ISandboxController, validAccessTokenMiddleware } from './modules/security';
 import { createExpressApplication, createExpressRouter } from './other/express.factory';
+import { version } from './version';
 
 export class App {
   public readonly express: Express;
@@ -72,6 +73,17 @@ export class App {
     this.express.use(cookieParser());
     this.express.use(urlencoded({ extended: true }));
     this.express.use(json());
+
+    this.express.use((req: Request, res: Response, next: NextFunction): void => {
+      res.header('X-WebApiVersion', version);
+      /**
+       * Expose the custom header to cross-origin requests.
+       *
+       * @see https://developer.mozilla.org/en-US/docs/Glossary/CORS-safelisted_response_header
+       */
+      res.header('Access-Control-Expose-Headers', 'X-WebApiVersion');
+      next();
+    });
 
     this.express.use((req: Request, res: Response, next: NextFunction): void => {
       const appReq: AppRequest = req as AppRequest;

--- a/web-api/src/common/error/app-error.ts
+++ b/web-api/src/common/error/app-error.ts
@@ -7,16 +7,16 @@ import * as HttpStatus from 'http-status-codes';
 
 export interface IAppErrorParameters {
   httpStatusCode?: number;
-  message: string;
+  message?: string;
   name: string;
-  originalError?: Readonly<Error>;
+  originalError?: unknown;
 }
 
 export class AppError extends Error implements IAppErrorParameters {
   public readonly httpStatusCode: number;
   public readonly message: string;
   public readonly name: string;
-  public readonly originalError?: Readonly<Error>;
+  public readonly originalError?: unknown;
 
   constructor(parameters: IAppErrorParameters) {
     // NOTE: To avoid `enumerable: false` issues, the Error class is called without any arguments.

--- a/web-api/src/common/error/get-error-response.ts
+++ b/web-api/src/common/error/get-error-response.ts
@@ -71,13 +71,13 @@ export function getErrorResponse(err: unknown): AppError {
     return new AppError({
       httpStatusCode: statusCode,
       message: innerError.message,
-      name: 'UNKNOWN_ERROR',
+      name: 'UNKNOWN_SERVER_ERROR',
     });
   } else if (typeof innerError === 'string') {
     return new AppError({
       httpStatusCode: statusCode,
       message: innerError,
-      name: 'UNKNOWN_ERROR',
+      name: 'UNKNOWN_SERVER_ERROR',
     });
   }
 

--- a/web-api/src/modules/security/middlewares/valid-access-token.middleware.ts
+++ b/web-api/src/modules/security/middlewares/valid-access-token.middleware.ts
@@ -6,7 +6,6 @@
 
 import { NextFunction } from 'express';
 
-import { UnauthorizedError } from '../../../common/error';
 import { isNil } from '../../../common/utils';
 import { AppRequest, AppResponse, UserContext } from '../../../core';
 import { IPasswordResetRequest } from '../services/account.service.interface';
@@ -29,6 +28,6 @@ export async function validAccessTokenMiddleware(req: AppRequest, res: AppRespon
     res.locals.userContext = userContext;
     return next();
   } catch (err) {
-    return next(new UnauthorizedError(err));
+    return next(err);
   }
 }

--- a/web-api/src/tsconfig.app.json
+++ b/web-api/src/tsconfig.app.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/tsconfig",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "exclude": [
     "**/*.spec.ts"

--- a/web-api/src/tsconfig.spec.json
+++ b/web-api/src/tsconfig.spec.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/tsconfig",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "extends": "../tsconfig.json",
   "exclude": []
 }

--- a/web-api/src/version.ts
+++ b/web-api/src/version.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line @typescript-eslint/no-require-imports,@typescript-eslint/no-var-requires
+export const version: string = require('../package.json').version;

--- a/web-api/tsconfig.json
+++ b/web-api/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json.schemastore.org/tsconfig",
+  "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
     "allowJs": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
## Why

The API clients need a way to validate the version of the API.

## What

* Add `X-WebApiVersion` header to all API responses and add it to the CORS safelist